### PR TITLE
20-05-29 bugs fixed

### DIFF
--- a/Pacemaker/app/src/main/java/com/devjj/pacemaker/core/extension/Const.kt
+++ b/Pacemaker/app/src/main/java/com/devjj/pacemaker/core/extension/Const.kt
@@ -1,9 +1,7 @@
 package com.devjj.pacemaker.core.extension
 
 import com.devjj.pacemaker.BuildConfig
-
-
-
+import java.util.*
 
 const val GET_HEIGHT_ONLY = 1
 
@@ -12,5 +10,17 @@ const val GET_WEIGHT_ONLY = 2
 const val GET_HEIGHT_WEIGHT = GET_HEIGHT_ONLY + GET_WEIGHT_ONLY
 //2020-05-27 marker_1
 /*val GET_HEIGHT_WEIGHT = 0*/
+
+const val EXERCISE_NAME_ENG_HOME_LEN_MAX = 20
+const val EXERCISE_NAME_ENG_PLAY_LEN_MAX = 16
+const val EXERCISE_NAME_ENG_HISTORY_LEN_MAX = 34
+const val EXERCISE_NAME_KOR_HOME_LEN_MAX = 11
+const val EXERCISE_NAME_KOR_PLAY_LEN_MAX = 8
+const val EXERCISE_NAME_KOR_HISTORY_LEN_MAX = 17
+
+const val EXERCISE_NAME_HOME = 0
+const val EXERCISE_NAME_PLAY = 1
+const val EXERCISE_NAME_HISTORY = 2
+
 
 const val APP_VERSION = BuildConfig.VERSION_NAME

--- a/Pacemaker/app/src/main/java/com/devjj/pacemaker/core/extension/String.kt
+++ b/Pacemaker/app/src/main/java/com/devjj/pacemaker/core/extension/String.kt
@@ -2,8 +2,69 @@ package com.devjj.pacemaker.core.extension
 
 import android.text.Editable
 import android.widget.EditText
+import com.devjj.pacemaker.core.functional.Dlog
+import java.util.*
 
 fun String.Companion.empty() = ""
 
 // editText에서 스트링 값 넣을 떄 쓰는 함수.
-fun String.Companion.editText(str: String) = Editable.Factory.getInstance().newEditable(str)
+fun String.Companion.editText(str: String): Editable = Editable.Factory.getInstance().newEditable(str)
+
+// 스트링을 길이로 짜르는 함수. position은 EXERCISE_NAME_HOME, EXERCISE_NAME_PLAY가 들어올 수 있다.
+fun String.Companion.regLen(str: String, position: Int): String{
+    val displayLanguage = Locale.getDefault().displayLanguage
+    // 글자 제한 크기
+    var maxLen = 0
+
+    // TODO : 안스가 해줌.
+    when(displayLanguage){
+        "English" -> {
+            when (position) {
+                EXERCISE_NAME_HOME -> {
+                    maxLen = EXERCISE_NAME_ENG_HOME_LEN_MAX
+                }
+                EXERCISE_NAME_PLAY -> {
+                    maxLen = EXERCISE_NAME_ENG_PLAY_LEN_MAX
+                }
+                EXERCISE_NAME_HISTORY -> {
+                    maxLen = EXERCISE_NAME_ENG_HISTORY_LEN_MAX
+                }
+            }
+        }
+        "한국어" -> {
+            when (position) {
+                EXERCISE_NAME_HOME -> {
+                    maxLen = EXERCISE_NAME_KOR_HOME_LEN_MAX
+                }
+                EXERCISE_NAME_PLAY -> {
+                    maxLen = EXERCISE_NAME_KOR_PLAY_LEN_MAX
+                }
+                EXERCISE_NAME_HISTORY -> {
+                    maxLen = EXERCISE_NAME_KOR_HISTORY_LEN_MAX
+                }
+            }
+        }
+        else -> {
+            when (position) {
+                EXERCISE_NAME_HOME -> {
+                    maxLen = EXERCISE_NAME_ENG_HOME_LEN_MAX
+                }
+                EXERCISE_NAME_PLAY -> {
+                    maxLen = EXERCISE_NAME_ENG_PLAY_LEN_MAX
+                }
+                EXERCISE_NAME_HISTORY -> {
+                    maxLen = EXERCISE_NAME_ENG_HISTORY_LEN_MAX
+                }
+            }
+        }
+    }
+
+    var result = str
+    Dlog.d("str.substring maxLen : ${maxLen}")
+    if(str.length >= maxLen){
+        Dlog.d("str.substring(0, maxLen-3) : ${str.substring(0, maxLen-3)}")
+        result = str.substring(0, maxLen-3)
+        result += "..."
+    }
+    return result
+}

--- a/Pacemaker/app/src/main/java/com/devjj/pacemaker/features/pacemaker/PacemakerActivity.kt
+++ b/Pacemaker/app/src/main/java/com/devjj/pacemaker/features/pacemaker/PacemakerActivity.kt
@@ -92,7 +92,7 @@ class PacemakerActivity : BaseActivity() {
 
         // 광고 테스트 코드
         val adRequest = AdRequest.Builder().build()
-        aPacemaker_adView.loadAd(adRequest)
+        aPacemaker_adView?.loadAd(adRequest)
         // TODO : 여기까지 인데. 광고 때문에 view로 매개변수 받아야 될 것 같음.
     }
 

--- a/Pacemaker/app/src/main/java/com/devjj/pacemaker/features/pacemaker/addition/AdditionFragment.kt
+++ b/Pacemaker/app/src/main/java/com/devjj/pacemaker/features/pacemaker/addition/AdditionFragment.kt
@@ -46,6 +46,7 @@ class AdditionFragment(private val intent: Intent) : BaseFragment() {
 
         // additionView의 name데이터를 이용하여 모드를 설정
         mode = if(additionView.name.isEmpty()) ADDITION_MODE else EDITING_MODE
+
         // 다크모드 설정
         isNightMode = setting.isNightMode
 
@@ -204,6 +205,8 @@ class AdditionFragment(private val intent: Intent) : BaseFragment() {
             EDITING_MODE -> {
                 additionData_id = tempAdditionView.id
                 additionData_part_img = tempAdditionView.part_img
+                val partImg = convertPartImgToResource(additionData_part_img, isNightMode)
+                fAddition_iv_part_main.setImageResource(partImg)
 
                 fAddition_tv_title.text = resources.getString(R.string.faddition_tv_title_edit_str)
                 fAddition_ev_name.text = String.editText(tempAdditionView.name)

--- a/Pacemaker/app/src/main/java/com/devjj/pacemaker/features/pacemaker/historydetail/HistoryDetailAdapter.kt
+++ b/Pacemaker/app/src/main/java/com/devjj/pacemaker/features/pacemaker/historydetail/HistoryDetailAdapter.kt
@@ -40,7 +40,7 @@ class HistoryDetailAdapter
         fun bind(historyDetailView: HistoryDetailView, context: Context,setting: SettingSharedPreferences,clickListener :(View,Int,String)->Unit={_,_,_->}){
             val partImgResource = convertPartImgToResource(historyDetailView.part_img, false)
             itemView.rvExerciseItem_iv_part.setImageResource(partImgResource)
-            itemView.rvExerciseItem_tv_name.text = historyDetailView.name
+            itemView.rvExerciseItem_tv_name.text = String.regLen(historyDetailView.name, EXERCISE_NAME_HISTORY)
            // itemView.rvExerciseItem_tv_mass.text = context.getString(R.string.rvexerciseitem_tv_unit_mass_str, historyDetailView.mass)
            // itemView.rvExerciseItem_tv_set.text = context.getString(R.string.unit_sets_goal_done, historyDetailView.setDone,historyDetailView.setGoal,historyDetailView.rep)
             itemView.rvExerciseItem_tv_mass.text = context.getString(R.string.unit_mass, historyDetailView.mass)

--- a/Pacemaker/app/src/main/java/com/devjj/pacemaker/features/pacemaker/historydetail/HistoryDetailFragment.kt
+++ b/Pacemaker/app/src/main/java/com/devjj/pacemaker/features/pacemaker/historydetail/HistoryDetailFragment.kt
@@ -38,14 +38,10 @@ import javax.inject.Inject
 class HistoryDetailFragment(private val intent: Intent) : BaseFragment() {
     override fun layoutId() = R.layout.fragment_history_detail
 
-    @Inject
-    lateinit var navigator: Navigator
-    @Inject
-    lateinit var db: ExerciseHistoryDatabase
-    @Inject
-    lateinit var historyDetailAdapter: HistoryDetailAdapter
+    @Inject lateinit var navigator: Navigator
+    @Inject lateinit var db: ExerciseHistoryDatabase
+    @Inject lateinit var historyDetailAdapter: HistoryDetailAdapter
     @Inject lateinit var setting: SettingSharedPreferences
-
 
     private lateinit var historyDetailViewModel: HistoryDetailViewModel
     private lateinit var historyDetailListener : HistoryDetailListener

--- a/Pacemaker/app/src/main/java/com/devjj/pacemaker/features/pacemaker/home/HomeAdapter.kt
+++ b/Pacemaker/app/src/main/java/com/devjj/pacemaker/features/pacemaker/home/HomeAdapter.kt
@@ -7,9 +7,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.devjj.pacemaker.R
 import com.devjj.pacemaker.core.di.sharedpreferences.SettingSharedPreferences
-import com.devjj.pacemaker.core.extension.convertPartImgToResource
-import com.devjj.pacemaker.core.extension.inflate
-import com.devjj.pacemaker.core.extension.loadColor
+import com.devjj.pacemaker.core.extension.*
 import com.devjj.pacemaker.features.pacemaker.addition.AdditionView
 import kotlinx.android.synthetic.main.recyclerview_exercise_item.view.*
 import javax.inject.Inject
@@ -39,7 +37,7 @@ class HomeAdapter
     class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         fun bind(homeView: HomeView, context: Context, setting: SettingSharedPreferences,
                  clickListener: (AdditionView) -> Unit, longClickListener: (HomeView) -> Unit) {
-            itemView.rvExerciseItem_tv_name.text = homeView.name
+            itemView.rvExerciseItem_tv_name.text = String.regLen(homeView.name, EXERCISE_NAME_HOME)
             itemView.rvExerciseItem_tv_mass.text = context.getString(R.string.unit_mass , homeView.mass)
             itemView.rvExerciseItem_tv_set.text = context.getString(R.string.unit_sets, homeView.set)
 

--- a/Pacemaker/app/src/main/java/com/devjj/pacemaker/features/pacemaker/playpopup/PlayPopupFragment.kt
+++ b/Pacemaker/app/src/main/java/com/devjj/pacemaker/features/pacemaker/playpopup/PlayPopupFragment.kt
@@ -468,6 +468,7 @@ class PlayPopupFragment : BaseFragment() {
                 progressBars[index].setBackgroundResource(resourcesSelect)
             }
         }
+
         //10-currentCount 깜빡이게
         var blinkAnim = AlphaAnimation(0.2f ,  1.0f)
         blinkAnim.duration = 500

--- a/Pacemaker/app/src/main/java/com/devjj/pacemaker/features/pacemaker/playpopup/PlayPopupFragment.kt
+++ b/Pacemaker/app/src/main/java/com/devjj/pacemaker/features/pacemaker/playpopup/PlayPopupFragment.kt
@@ -359,7 +359,7 @@ class PlayPopupFragment : BaseFragment() {
         fPlayPopup_iv_part_img.setImageResource(partImgResources)
         //
 
-        fPlayPopup_tv_name.text = currentPlayPopupView.name
+        fPlayPopup_tv_name.text = String.regLen(currentPlayPopupView.name, EXERCISE_NAME_PLAY)
         var slash = getString(R.string.template_slash_str)
         var massUnit = getString(R.string.fplaypopup_tv_unit_mass_str)
         var repUnit = getString(R.string.fplaypopup_tv_unit_rep_str)
@@ -392,7 +392,6 @@ class PlayPopupFragment : BaseFragment() {
     fun settingRestTimeTv(){
         val timerText = settingFormatForTimer(interval)
         fPlayPopup_tv_rest_time.text = timerText
-
     }
 
     // 모드별 화면 셋팅
@@ -423,7 +422,6 @@ class PlayPopupFragment : BaseFragment() {
         params.setMargins(topMarginInt, topMarginInt, topMarginInt, topMarginInt)
         fPlayPopup_iv_part_img.layoutParams = params
     }
-
 
     // progressbar setting(초기 progressBar setting)
     // input값은 총 갯수

--- a/Pacemaker/app/src/main/java/com/devjj/pacemaker/features/pacemaker/playpopup/PlayPopupListener.kt
+++ b/Pacemaker/app/src/main/java/com/devjj/pacemaker/features/pacemaker/playpopup/PlayPopupListener.kt
@@ -77,7 +77,7 @@ class PlayPopupListener(val activity: Activity, val playPopupFragment: PlayPopup
         // +10초 눌렀을 때수 이벤트 함수
         activity.fPlayPopup_flo_plus.setOnClickListener {
             if(plusClickNumber <= maxPlusClickNumber) plusClickNumber++
-            if(plusClickNumber <= maxPlusClickNumber) interval+=plusInterval
+            if(plusClickNumber <= maxPlusClickNumber&& interval != 0) interval+=plusInterval
 
             // 휴식 시간 타이머 시간 조정하는 함수
             playPopupFragment.settingRestTimeTv()

--- a/Pacemaker/app/src/main/res/layout/fragment_play_popup.xml
+++ b/Pacemaker/app/src/main/res/layout/fragment_play_popup.xml
@@ -204,7 +204,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/fPlayPopup_clo_exercise_content"
-        android:layout_width="200dp"
+        android:layout_width="220dp"
         android:layout_height="60dp"
         android:layout_marginTop="25dp"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
운동 재생에서 운동 리스트가 하나일때 마지막 세트 후 종료하면 휴식시간 돌아감 수정해야 됨.(o)
재생 화면에서 추가 휴식시간(+10초) 클릭했을 때 딜레이 문제 해결(o)
상체 운동, 팔 운동, 가슴 운동, 복근 운동, 다리 운동, 어깨 운동를 디폴트 운동(o)
추가값으로하고 빈칸을 넘겼을 시 한번 물어보고 다시 눌렀을 때 추가함.(o)
홈에서 편집모드로 들어갈때 이미지가 변하지 않는다.(o)
00:00초에서 추가시간 누르면 시간이 추가되는 현상 수정해야 됨(o)
운동 재생을 할 때 운동 이름이 너무 길면 뒤에 … 으로 바꾸는 작업 필요한듯, 할 때 영어 인지(o) 
